### PR TITLE
Fix job names

### DIFF
--- a/audit-dotnet-core/.gitlab-ci.yml
+++ b/audit-dotnet-core/.gitlab-ci.yml
@@ -16,7 +16,7 @@ default:
 
 include:
   - remote: "https://releases.jfrog.io/artifactory/jfrog-cli/gitlab/.setup-jfrog.yml"
-jfrog-nuget-audit:
+jfrog-dotnet-audit:
   script:
     - !reference [.setup_jfrog, script]
 

--- a/audit-go/.gitlab-ci.yml
+++ b/audit-go/.gitlab-ci.yml
@@ -14,7 +14,7 @@ default:
 
 include:
   - remote: "https://releases.jfrog.io/artifactory/jfrog-cli/gitlab/.setup-jfrog.yml"
-jfrog-npm-audit:
+jfrog-go-audit:
   script:
     - !reference [.setup_jfrog, script]
 

--- a/build-dotnet-core/.gitlab-ci.yml
+++ b/build-dotnet-core/.gitlab-ci.yml
@@ -13,7 +13,7 @@ default:
 
 include:
   - remote: "https://releases.jfrog.io/artifactory/jfrog-cli/gitlab/.setup-jfrog.yml"
-jfrog-dotnet-audit:
+jfrog-dotnet-build:
   script:
     - !reference [.setup_jfrog, script]
 


### PR DESCRIPTION
Hey, I saw some job names were wrong.
I addition to that, others suggestions will be:
- To rename job name to fit the repository name (Ex: Rename jfrog-go-audit --> jfrog-audit-go) to be compliant with folder name.
- Set default stage for each job (Build or Test)

What do you think ?